### PR TITLE
finalizing tensorflow graph to avoid memory leak

### DIFF
--- a/src/nn/bidder.py
+++ b/src/nn/bidder.py
@@ -14,6 +14,8 @@ class Bidder:
         self.graph = tf.Graph()
         self.sess = tf.Session(graph=self.graph)
         self.load_model()
+        self.output_softmax = tf.nn.softmax(self.graph.get_tensor_by_name('out_bid_logit:0'))
+        self.graph.finalize()
         self.lstm_size = 128
         self.zero_state = (
             State(c=np.zeros((1, self.lstm_size)), h=np.zeros((1, self.lstm_size))),
@@ -93,7 +95,7 @@ class Bidder:
                     keep_prob: p_keep,
                     seq_in: x,
                 }
-                result = self.sess.run(tf.nn.softmax(out_bid_logit), feed_dict=feed_dict)
+                result = self.sess.run(self.output_softmax, feed_dict=feed_dict)
             return result
         
         return pred_fun_seq, pred_fun

--- a/src/nn/player.py
+++ b/src/nn/player.py
@@ -1,6 +1,8 @@
 import numpy as np
 import tensorflow as tf
 
+from scipy.special import softmax
+
 
 SUIT_MASK = np.array([
     [1] * 8 + [0] * 24,
@@ -18,6 +20,7 @@ class BatchPlayer:
         self.graph = tf.Graph()
         self.sess = tf.Session(graph=self.graph)
         self.load_model()
+        self.graph.finalize()
         self.model = self.init_model()
 
     def close(self):
@@ -47,7 +50,7 @@ class BatchPlayer:
         return pred_fun
 
     def reshape_card_logit(self, card_logit, x):
-        return self.sess.run(tf.nn.softmax(card_logit.reshape((x.shape[0], x.shape[1], 32))))#[:,-1,:]
+        return softmax(card_logit.reshape((x.shape[0], x.shape[1], 32)), axis=2)
 
     def next_cards_softmax(self, x):
         return self.model(x)[:,-1,:]
@@ -56,7 +59,7 @@ class BatchPlayer:
 class BatchPlayerLefty(BatchPlayer):
 
     def reshape_card_logit(self, card_logit, x):
-        return self.sess.run(tf.nn.softmax(card_logit.reshape((x.shape[0], x.shape[1] - 1, 32))))#[:,-1,:]
+        return softmax(card_logit.reshape((x.shape[0], x.shape[1] - 1, 32)), axis=2)
 
 
 def follow_suit(cards_softmax, own_cards, trick_suit):


### PR DESCRIPTION
the problem was that each call to `tf.nn.softmax` added a new node into the computation graph thus making it bigger and leaking memory.

`graph.finalize()` prevents any changes to the graph.