### PR TITLE
Fix uninformative server error alerts; add pre-flight connectivity check

### DIFF
--- a/src/frontend/bridge.html
+++ b/src/frontend/bridge.html
@@ -162,7 +162,7 @@
 
             ws.addEventListener("error", function (event) {
                 console.log("WebSocket error:", event);
-                alert("Error on server: ", location.hostname + ":"+  serverport,  event )
+                alert("Cannot connect to server on port " + serverport + ".\nIs the correct BEN server running?\nStart it with: python gameserver.py")
                 document.querySelector('#auctionstr').innerHTML += 'No connection to server <br>'
             });
 

--- a/src/frontend/views/home.tpl
+++ b/src/frontend/views/home.tpl
@@ -337,8 +337,22 @@ let selectedForm = null;
 
 
 // Function to include checkbox values in form submission
-function includeCheckboxValues(event) {
+async function includeCheckboxValues(event) {
     event.preventDefault(); // Prevents the default form submission
+
+    // Pre-flight: verify the selected server port is reachable before redirecting
+    const serverValue = document.getElementById('server').value;
+    const serverPort = '444' + serverValue;
+    const reachable = await new Promise((resolve) => {
+        const ws = new WebSocket('ws://localhost:' + serverPort + '/');
+        const timer = setTimeout(() => { ws.close(); resolve(false); }, 1500);
+        ws.onopen  = () => { clearTimeout(timer); ws.close(); resolve(true); };
+        ws.onerror = () => { clearTimeout(timer); resolve(false); };
+    });
+    if (!reachable) {
+        alert('No BEN server found on port ' + serverPort + '.\nPlease start the server or choose a different server in the dropdown.');
+        return;
+    }
 
     if (selectedForm && !formerror) {
         const formData = new FormData(selectedForm);


### PR DESCRIPTION
## Problem

When a user selects a server from the home page dropdown and starts a game, but the
corresponding server process is not running on the expected port, the experience is
confusing:

1. The user is redirected to `bridge.html` with no warning.
2. The WebSocket connection attempt fails silently in the background.
3. Two sequential `alert()` dialogs appear: **"Error on server:"** (no port, no hint)
   followed by **"Connection died"**.

The root cause is two bugs working together:

**Bug 1 — `bridge.html`:** `alert()` only accepts one argument. The call
`alert("Error on server: ", hostname + ":" + port, event)` silently drops the second
and third arguments, showing only the useless string `"Error on server:"` with no port
number or remediation hint.

**Bug 2 — `home.tpl`:** The server dropdown selection is persisted in `localStorage`.
If the user has ever selected (e.g.) "BEN 2/1" (port 4440) but only the "Default 21GF"
server (port 4443) is running, every future visit will silently fail — with no warning
on the home page before the redirect.

## Changes

**`src/frontend/bridge.html`** — fix the error alert to include the port and a startup
hint (one line change; the extra arguments to `alert()` were silently dropped by the
browser):

```diff
-                alert("Error on server: ", location.hostname + ":"+  serverport,  event )
+                alert("Cannot connect to server on port " + serverport + ".\nIs the correct BEN server running?\nStart it with: python gameserver.py")
```

**`src/frontend/views/home.tpl`** — add an async pre-flight WebSocket connectivity
check that fires before the form submits. If the selected port is unreachable the user
sees a clear message on the home page and can correct their dropdown selection without
losing form state:

```diff
-function includeCheckboxValues(event) {
+async function includeCheckboxValues(event) {
     event.preventDefault(); // Prevents the default form submission

+    // Pre-flight: verify the selected server port is reachable before redirecting
+    const serverValue = document.getElementById('server').value;
+    const serverPort = '444' + serverValue;
+    const reachable = await new Promise((resolve) => {
+        const ws = new WebSocket('ws://localhost:' + serverPort + '/');
+        const timer = setTimeout(() => { ws.close(); resolve(false); }, 1500);
+        ws.onopen  = () => { clearTimeout(timer); ws.close(); resolve(true); };
+        ws.onerror = () => { clearTimeout(timer); resolve(false); };
+    });
+    if (!reachable) {
+        alert('No BEN server found on port ' + serverPort + '.\nPlease start the server or choose a different server in the dropdown.');
+        return;
+    }
+
     if (selectedForm && !formerror) {
```

## Why a pre-flight check?

The server dropdown value is persisted in `localStorage`. A user who last played with
"BEN 2/1" selected will silently hit the wrong port on every future visit until they
notice and change the dropdown. The pre-flight check catches this on the home page —
before the redirect — when the fix is a one-click dropdown change rather than two
confusing alert dialogs after the fact.

The 1500 ms timeout is conservative; a locally running server typically responds in
under 50 ms. If the server is not running, `onerror` fires immediately.

## Testing

- Start `gameserver.py` (default port 4443). Select **Default (21GF)** → form submits
  normally.
- With the same server running, select **BEN 2/1** (port 4440) → pre-flight fires,
  alert shows port 4440, form does not submit.
- With no server running → alert fires on any selection.
