### PR TITLE
Fix KeyError: 'Hint' that closes the connection when Hint is clicked mid-auction

### DIFF
--- a/src/human.py
+++ b/src/human.py
@@ -137,7 +137,17 @@ class HumanBidSocket:
 
         print(f"Human bid: {bid}")
         print("auction: ", auction)
-        new_auction = auction + [bid] 
+
+        # "Hint" and "Alert" are UI controls, not calls - the driver handles them
+        # and never appends them to the auction. Explaining an auction with one
+        # of them tacked on reaches BBA's BID2ID lookup and raises KeyError,
+        # killing the connection with a 1011. (Only visible once BBA is enabled,
+        # and only after a real bid exists, since explain() bails out early in
+        # both of those cases.)
+        if bid in ("Hint", "Alert"):
+            return BidResp(bid=bid, candidates=[], samples=[], shape=-1, hcp=-1, who = "Human", quality=None, alert=False, explanation=None)
+
+        new_auction = auction + [bid]
         explanation, alert = self.botbidder.explain(new_auction)
 
         return BidResp(bid=bid, candidates=[], samples=[], shape=-1, hcp=-1, who = "Human", quality=None, alert=alert, explanation=explanation)


### PR DESCRIPTION
## Problem

Clicking **Hint** during the auction kills the game. The board freezes, and the browser
console shows the websocket closing with `code=1011` (internal error) and an empty reason.

Nothing appears in the gameserver log, because `gameserver.py` sets the `websockets.server`
logger to `CRITICAL`, which suppresses the handler traceback. The log simply ends at:

```
Human bid: Hint
auction:  ['PAD_START', 'PASS', '2D', '2H', '3D', '4H']
```

Running a copy of `gameserver.py` with that logger at `DEBUG` shows the real cause:

```
  File "src/human.py", line 141, in async_bid
    explanation, alert = self.botbidder.explain(new_auction)
  File "src/botbidder.py", line 83, in explain
    return self.bbabot.explain_last_bid(auction)
  File "src/bba/BBA.py", line 633, in explain_last_bid
    bidid = bidding.BID2ID[auction[k]]
KeyError: 'Hint'
```

## Root cause

The Hint button sends the literal string `"Hint"` over the socket, the same channel as a
call. `HumanBidSocket.async_bid` appends whatever arrives to the auction and asks BBA to
explain it:

```python
new_auction = auction + [bid]          # bid == "Hint"
explanation, alert = self.botbidder.explain(new_auction)
```

`"Hint"` is not in `BID2ID`, so the lookup raises and the connection dies.

Both `game.py` and the client already treat `Hint` and `Alert` as controls rather than
calls — `game.py` intercepts them after `async_bid` returns, and `bridge.html`'s
`callClick` branches on them — so they should never reach the explainer.

## Why this has not been reported before

Two early returns in `BotBid.explain` hide it:

1. `if not self.models.consult_bba or self.bbabot is None: return None, False` — BBA was
   disabled on every non-Windows platform before 0.8.8.x, so the line never ran there.
2. `if not any(bidding.BID2ID.get(bid, 0) >= 2 for bid in auction): return None, False` —
   so a hint requested before any real bid is made returns early and works.

Together those mean the bug appears only once BBA is enabled *and* the auction contains a
real bid. That is why the first Hint of a session appears to work and a later one does not.

## Fix

Return the control strings unexplained, matching what the driver and the client already do:

```diff
+        if bid in ("Hint", "Alert"):
+            return BidResp(bid=bid, candidates=[], samples=[], shape=-1, hcp=-1, who = "Human", quality=None, alert=False, explanation=None)
+
         new_auction = auction + [bid]
         explanation, alert = self.botbidder.explain(new_auction)
```

## Testing

macOS 26.6.1, Python 3.12, BEN 0.8.8.4, `BBA enabled. Version 8740`.

Reproduce (fails before the change with `ConnectionClosedError ... 1011`, passes after):

```python
import asyncio, websockets, json
async def main():
    turn = 0
    async with websockets.connect("ws://127.0.0.1:4443/?S=x&T=2") as ws:
        while True:
            d = json.loads(await asyncio.wait_for(ws.recv(), timeout=180))
            m = d.get("message")
            if m == "get_bid_input":
                turn += 1
                await ws.send("Hint" if turn >= 2 else "PASS")   # turn 1 works either way
            elif m == "hint":
                print("hint ->", d["bids"]["bid"]); await ws.send("PASS")
            elif m == "auction_end":
                print("auction completed"); break
asyncio.run(main())
```

Also verified by requesting a hint on *every* turn of a full auction: all answered, auction
reached `auction_end`, server still serving afterwards.
