### PR TITLE
Fix server spinning at 100% CPU and refusing all connections after a player disconnects

### DIFF
--- a/src/human.py
+++ b/src/human.py
@@ -1,5 +1,6 @@
 import json
 import numpy as np
+import websockets
 
 import deck52
 
@@ -171,6 +172,14 @@ class HumanLeadSocket:
                 else:    
                     return CardResp(card=Card.from_symbol(human_card), candidates=candidates, samples=samples, shape=-1, hcp=-1, quality=None, who = "Human", claim = -1)
 
+            # Give up as soon as the socket is gone. Retrying a dead connection
+            # spins this loop at full CPU, which starves the event loop and
+            # stops the server answering anyone else. The "going away" check
+            # below only catches one of the several close reasons websockets
+            # reports - a browser tab closing yields "no close frame received
+            # or sent" or "received 1000 (OK)".
+            except websockets.exceptions.ConnectionClosed:
+                raise
             except Exception as ex:
                 print(f"Exception receiving card ", ex)
                 if "going away" in str(ex):
@@ -267,6 +276,10 @@ class HumanCardPlayerSocket(HumanCardPlayer):
                     return human_card
                 else:
                     return deck52.encode_card(human_card)
+            # See the note in HumanLead.async_lead - a closed socket must end
+            # the loop, not be retried forever.
+            except websockets.exceptions.ConnectionClosed:
+                raise
             except Exception as ex:
                 print(f"Exception receiving card", ex)
                 if "going away" in str(ex):


### PR DESCRIPTION
## Problem

When a player disconnects while it is their turn to play a card — closing the browser tab,
navigating away, losing the network — the gameserver does not clean up the deal. It pins a
CPU core at ~99% and stops answering **everyone**: new websocket connections no longer
complete their opening handshake, so from a browser the server looks like it has vanished.
The `/home` pre-flight check added in #181 reports "No BEN server found on port 4443" even
though the process is running.

It also writes one log line per iteration. Measured on an otherwise idle machine:

```
3,227,770 lines / 208 MB in roughly two minutes
...
Exception receiving card  received 1000 (OK); then sent 1000 (OK)
Exception receiving card  received 1000 (OK); then sent 1000 (OK)
```

Recovery requires killing the process.

## Root cause

Both card-input loops — `HumanLeadSocket.async_lead` and
`HumanCardPlayer.get_card_input` — catch every exception and only re-raise when the message
text contains `"going away"`:

```python
            except Exception as ex:
                print(f"Exception receiving card ", ex)
                if "going away" in str(ex):
                    raise ex
```

`"going away"` is only one of the ways `websockets` reports a closed connection. An ordinary
browser close surfaces as `received 1000 (OK); then sent 1000 (OK)`, and a dropped
connection as `no close frame received or sent`. Neither matches, so control falls to the
bottom of the `while True:` and the loop sends `get_card_input` to a dead socket again,
forever, as fast as the event loop allows.

Because this is a hot loop inside the asyncio event loop, it starves every other task in the
process — hence new connections timing out rather than just the one deal leaking.

## Fix

Let `ConnectionClosed` propagate. A disconnected player means the deal is over, which is what
the exception already signals; the surrounding code handles it. The `"going away"` branch is
left alone for the other error paths.

```diff
+            except websockets.exceptions.ConnectionClosed:
+                raise
             except Exception as ex:
                 print(f"Exception receiving card ", ex)
                 if "going away" in str(ex):
                     raise ex
```

Applied to both loops, plus `import websockets` at the top of `human.py`.

## Testing

macOS 26.6.1, Python 3.12, `websockets` 16.0, BEN 0.8.8.4.

Reproduce by connecting as a human player, bidding to the play phase, then closing the socket
at the first `get_card_input`:

```python
import asyncio, websockets, json
async def main():
    ws = await websockets.connect("ws://127.0.0.1:4443/?S=x&T=2")
    while True:
        d = json.loads(await asyncio.wait_for(ws.recv(), timeout=180))
        m = d.get("message")
        if m == "get_bid_input":
            await ws.send("PASS")
        elif m == "get_card_input":
            await ws.close(); break        # what a closing browser tab looks like
asyncio.run(main())
```

Then `ps -o %cpu -p <gameserver pid>` and `wc -l logs/gameserver.log`.

| | before | after |
| --- | --- | --- |
| CPU 10s after disconnect | ~99% | 0.0% |
| log lines | millions, still growing | 83, static |
| new player can connect | no (handshake times out) | yes, immediately |

Verified afterwards that a fresh connection is served a board and plays a full auction.
