### PR TITLE
Default the server dropdown to the port a single gameserver listens on

### DIFF
--- a/src/frontend/views/home.tpl
+++ b/src/frontend/views/home.tpl
@@ -56,7 +56,10 @@
             <option value="0">BEN 2/1</option>
             <option value="1">BEN SAYC</option>
             <option value="2">GIB-BBO</option>
-            <option value="3">Default (21GF)</option>
+            <!-- Default selection: port 4443, the one gameserver.py and
+                 start_ben.sh use. The other three only exist if you started
+                 the extra instances with src/runservers.sh. -->
+            <option value="3" selected>Default (21GF)</option>
         </select><br>
         </div>
     </div>


### PR DESCRIPTION
## Problem

A fresh browser profile that starts one gameserver the documented way — `python gameserver.py`,
or the container's `start_ben_all.sh` — and clicks through the home page is told:

```
No BEN server found on port 4440.
Please start the server or choose a different server in the dropdown.
```

The server dropdown lists four options and no option is marked `selected`, so the browser
picks the first one, "BEN 2/1" = port 4440. But a single `gameserver.py` listens on 4443, and
ports 4440-4442 only exist if the extra instances were started with `src/runservers.sh`.

So the out-of-the-box server and the out-of-the-box dropdown selection disagree, and the
first thing a new user sees is an error naming a port they never chose.

## Relationship to #181

This is a small follow-up to #181, not a disagreement with it. That PR added the pre-flight
check precisely because a stale `localStorage` value silently sends people to the wrong port,
and warning on the home page — where correcting it is one click — is the right call. Its test
plan starts from "select **Default (21GF)** → form submits normally".

This change only makes that selection the starting point, so the default configuration does
not need the warning at all. The pre-flight check still does its job for anyone who has
picked another server, and an explicit choice is still remembered in `localStorage`.

## Fix

```diff
-            <option value="3">Default (21GF)</option>
+            <option value="3" selected>Default (21GF)</option>
```

`/play` already forces this value (`serverdropdown.value = 3` when `play` is true), so this
brings `/home` in line with it.

## Alternative

If you would rather the dropdown reflect what is actually running, the pre-flight probe could
be run against all four ports on page load and unreachable ones disabled. That is a bigger
change and more websocket churn on every visit, so I went with the one-line default. Happy to
do it the other way if you prefer.

## Testing

- Fresh profile (no `localStorage`), one `gameserver.py` on 4443 → "Default (21GF)"
  preselected, form submits, board plays. Previously alerted about port 4440.
- Select "BEN 2/1" with nothing on 4440 → pre-flight still alerts, as designed in #181.
- Select "BEN 2/1", reload → choice still remembered, so the change does not override an
  explicit selection.
